### PR TITLE
Fix JDBC connection reuse

### DIFF
--- a/src/main/java/Bd/app/MainApp.java
+++ b/src/main/java/Bd/app/MainApp.java
@@ -11,9 +11,13 @@ import java.util.List;
 
 public class MainApp {
     public static void main(String[] args) {
-        Connection conn = DbUtil.getConnection();
-        if (conn == null) {
-            System.err.println("Nu s-a putut obtine conexiunea");
+        try (Connection conn = DbUtil.getConnection()) {
+            if (conn == null) {
+                System.err.println("Nu s-a putut obtine conexiunea");
+                return;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
             return;
         }
 

--- a/src/main/java/Bd/util/DbUtil.java
+++ b/src/main/java/Bd/util/DbUtil.java
@@ -8,15 +8,16 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 public class DbUtil {
-    private static Connection connection;
-
     private DbUtil() {
     }
 
+    /**
+     * Opens a new JDBC connection using the parameters from {@code db.properties}.
+     * <p>
+     * Each call creates a fresh {@link Connection} to avoid reusing a potentially
+     * closed one. Callers are responsible for closing the returned connection.
+     */
     public static Connection getConnection() {
-        if (connection != null) {
-            return connection;
-        }
         Properties props = new Properties();
         try (InputStream is = DbUtil.class.getClassLoader().getResourceAsStream("db.properties")) {
             if (is != null) {
@@ -27,10 +28,10 @@ public class DbUtil {
             String user = props.getProperty("username");
             String pass = props.getProperty("password");
             Class.forName(driver);
-            connection = DriverManager.getConnection(url, user, pass);
+            return DriverManager.getConnection(url, user, pass);
         } catch (IOException | ClassNotFoundException | SQLException e) {
             e.printStackTrace();
+            return null;
         }
-        return connection;
     }
 }


### PR DESCRIPTION
## Summary
- avoid keeping a static connection in `DbUtil`
- open a new connection on each call to `getConnection`
- use try-with-resources when testing connection in `MainApp`

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684138997e24832986a69beaeeb1e2dd