### PR TITLE
Fix Gradle toolchain for available JDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,8 @@ tasks.named('run') {
 }
 java {
 
-    toolchain { languageVersion = JavaLanguageVersion.of(24) }
+    // Use JDK 21 which is available in the build environment
+    toolchain { languageVersion = JavaLanguageVersion.of(21) }
 }
 
 application {
@@ -25,7 +26,8 @@ application {
 }
 
 javafx {
-    version = '24'
+    // Version 21 is compatible with the available JDK 21 toolchain
+    version = '21'
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 


### PR DESCRIPTION
## Summary
- use Java 21 toolchain and JavaFX 21

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6841404ff52c8329a06040a1bf8afb09